### PR TITLE
Use new subscribeWithSelector api

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,14 +34,14 @@ export function share<T extends State, K extends keyof T>(
     let timestamp = 0;
 
     let cleanup = api.subscribe(
+        (state) => state[key],
         (state) => {
             if (!externalUpdate) {
                 timestamp = Date.now();
                 channel.postMessage({ timestamp, state });
             }
             externalUpdate = false;
-        },
-        (state) => state[key]
+        }
     );
     channel.onmessage = (evt) => {
         if (evt.data === undefined) {


### PR DESCRIPTION
In subscribeWithSelector from `zustand/middleware`, the selector goes first. Maybe this should be a major version bump.