### PR TITLE
Add typing for store and allow for sharing complex objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ if ("BroadcastChannel" in globalThis /* || isSupported() */) {
 ```
 
 
-## API (has never changed)
+## API
 
 ```js
 share("count", useStore, {
@@ -83,6 +83,14 @@ share("count", useStore, {
         stores with the same name, set this to something unique.
     */
     ref: "shared-store",
+    /*
+        BroadcastChannel uses structured cloning to communicate values.
+        This works great for most JS value, not for complex objects (such as instances of classes) however.
+        The serialize & unserialize functions allow you to define a serialized representation for a complex object
+        and restore it later from the serialized value.
+    */
+    serialize: (value) => JSON.stringify(value),
+    unserialize: (serialized) => JSON.parse(serialized),
 });
 ```
 

--- a/example/index.html
+++ b/example/index.html
@@ -10,6 +10,6 @@
         <div id="root">
             Open the console in two different tabs
         </div>
-        <script src="index.js" type="module"></script>
+        <script src="index.ts" type="module"></script>
     </body>
 </html>

--- a/example/index.ts
+++ b/example/index.ts
@@ -4,27 +4,48 @@ import { subscribeWithSelector} from "zustand/middleware";
 
 import { share } from "../src";
 
+class ComplexCounter {
+    constructor(
+        public readonly count: number,
+    ) {}
+
+    public increment() {
+        return new ComplexCounter(this.count + 1);
+    }
+
+    public toString() {
+        return `Complex count: ${this.count}`
+    }
+}
 
 interface CountStore {
     count: number;
     nested: { count: number };
+    complexCount: ComplexCounter;
     inc: (i?: number) => void;
     dec: (i?: number) => void;
     incNested: (i?: number) => void;
     decNested: (i?: number) => void;
+    incComplex: () => void;
 }
 const UseCount = createStore<CountStore>()(subscribeWithSelector((set) => ({
     count: 0,
     nested: { count: 0 },
+    complexCount: new ComplexCounter(0),
     inc: (i = 1) => set(({ count }) => ({ count: count + i })),
     dec: (i = 1) => set(({ count }) => ({ count: count - i })),
     incNested: (i = 1) => set(({ nested: { count } }) => ({ nested: { count: count + i } })),
     decNested: (i = 1) => set(({ nested: { count } }) => ({ nested: { count: count - i } })),
+    incComplex: () => set(({ complexCount }) => ({ complexCount: complexCount.increment() })),
 })));
 
 share("count", UseCount);
 // The "nested" prop is synced on startup
 share("nested", UseCount, { initialize: true });
+share("complexCount", UseCount, {
+    serialize: (value) => `${value.count}`,
+    unserialize: (serialized) => new ComplexCounter(parseInt(serialized, 10)),
+});
 
 UseCount.subscribe(
     (count) => {
@@ -36,6 +57,7 @@ UseCount.subscribe(
     (count) => {
         console.log("Count: " + count.count);
         console.log("Nested count: " + count.nested.count);
+        console.log(count.complexCount.toString());
     }
 );
 declare global {
@@ -44,16 +66,19 @@ declare global {
         dec: CountStore["dec"];
         incNested: CountStore["incNested"];
         decNested: CountStore["incNested"];
+        incComplex: CountStore["incComplex"];
     }
 }
 window.inc = UseCount.getState().inc;
 window.dec = UseCount.getState().dec;
 window.incNested = UseCount.getState().incNested;
 window.decNested = UseCount.getState().decNested;
+window.incComplex = UseCount.getState().incComplex;
 
 console.log(`Open the console in two tabs side by side and experiment what happens if you call:
     inc(i);
     dec(i);
     incNested(i);
-    decNested(i);   
+    decNested(i);
+    incComplex();
 `);

--- a/package.json
+++ b/package.json
@@ -19,11 +19,13 @@
         "start": "parcel serve example/index.html --no-hmr",
         "watch": "parcel watch"
     },
+    "peerDependencies": {
+        "zustand": "^4.3.7"
+    },
     "devDependencies": {
         "@parcel/packager-ts": "^2.8.3",
         "@parcel/transformer-typescript-types": "^2.8.3",
         "parcel": "^2.0.0",
-        "zustand": "^4.3.7",
         "@types/node":"^18.15.11"
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,6 @@
 import { StoreApi, StoreMutators } from "zustand";
+// NOTE: imports the typing for SubscribeWithSelector
+import "zustand/middleware";
 
 export function isSupported() {
     return "BroadcastChannel" in globalThis;


### PR DESCRIPTION
This PR adds typing for the `key` and `api` parameters for `share`.
Further it allows to use `shared-zustand` for complex objects which are not fully supported by structured cloning. Such as Luxon datetime objects.

I did my best to adhere to coding standards and update the example and readme as best as possible to reflect the changes.